### PR TITLE
Refactor 'TransactionLimits' types/config

### DIFF
--- a/src/Lightning.ts
+++ b/src/Lightning.ts
@@ -303,7 +303,7 @@ export const LightningMixin = (superclass) =>
             const lightningLoggerOnUs = lightningLogger.child({ onUs: true, fee: 0 })
 
             if (await this.user.limitHit({ on_us: true, amount: tokens })) {
-              const error = `Cannot transfer more than ${this.config.limits.onUsLimit()} sats in 24 hours`
+              const error = `Cannot transfer more than ${this.config.limits.onUsLimit} sats in 24 hours`
               throw new TransactionRestrictedError(error, { logger: lightningLoggerOnUs })
             }
 
@@ -430,12 +430,12 @@ export const LightningMixin = (superclass) =>
 
           // "normal" transaction: paying another lightning node
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit()}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: lightningLogger })
           }
 
           if (await this.user.limitHit({ on_us: false, amount: tokens })) {
-            const error = `Cannot transfer more than ${this.config.limits.withdrawalLimit()} sats in 24 hours`
+            const error = `Cannot transfer more than ${this.config.limits.withdrawalLimit} sats in 24 hours`
             throw new TransactionRestrictedError(error, { logger: lightningLogger })
           }
 

--- a/src/OnChain.ts
+++ b/src/OnChain.ts
@@ -171,7 +171,7 @@ export const OnChainMixin = (superclass) =>
             if (
               await this.user.limitHit({ on_us: true, amount: amountToSendPayeeUser })
             ) {
-              const error = `Cannot transfer more than ${this.config.limits.onUsLimit()} sats in 24 hours`
+              const error = `Cannot transfer more than ${this.config.limits.onUsLimit} sats in 24 hours`
               throw new TransactionRestrictedError(error, { logger: onchainLoggerOnUs })
             }
 
@@ -209,7 +209,7 @@ export const OnChainMixin = (superclass) =>
           onchainLogger = onchainLogger.child({ onUs: false })
 
           if (!this.user.oldEnoughForWithdrawal) {
-            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit()}h before withdrawing`
+            const error = `New accounts have to wait ${this.config.limits.oldEnoughForWithdrawalLimit}h before withdrawing`
             throw new NewAccountWithdrawalError(error, { logger: onchainLogger })
           }
 
@@ -223,7 +223,7 @@ export const OnChainMixin = (superclass) =>
           }
 
           if (await this.user.limitHit({ on_us: false, amount: checksAmount })) {
-            const error = `Cannot withdraw more than ${this.config.limits.withdrawalLimit()} sats in 24 hours`
+            const error = `Cannot withdraw more than ${this.config.limits.withdrawalLimit} sats in 24 hours`
             throw new TransactionRestrictedError(error, { logger: onchainLogger })
           }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,31 +21,29 @@ try {
 
 export const yamlConfig = _.merge(defaultConfig, customConfig)
 
-export class TransactionLimits implements ITransactionLimits {
-  readonly config
-  readonly level
+const limitConstants = {
+  oldEnoughForWithdrawalHours: yamlConfig.limits.oldEnoughForWithdrawal / MS_IN_HOUR,
+  oldEnoughForWithdrawalMicroseconds: yamlConfig.limits.oldEnoughForWithdrawal,
+}
 
-  constructor({ level }) {
-    this.config = yamlConfig.limits
-    this.level = level
+export const selectUserLimits = ({ level }: { level: number }): IUserLimits => {
+  const config = yamlConfig.limits
+  return {
+    onUsLimit: config.onUs.level[level],
+    withdrawalLimit: config.withdrawal.level[level],
   }
-
-  onUsLimit = () => this.config.onUs.level[this.level]
-
-  withdrawalLimit = () => this.config.withdrawal.level[this.level]
-
-  oldEnoughForWithdrawalLimit = () => this.config.oldEnoughForWithdrawal / MS_IN_HOUR
 }
 
 export const getUserWalletConfig = (user): UserWalletConfig => {
-  const transactionLimits = new TransactionLimits({
-    level: user.level,
-  })
+  const userLimits = selectUserLimits({ level: user.level })
 
   return {
     name: yamlConfig.name,
     dustThreshold: yamlConfig.onChainWallet.dustThreshold,
-    limits: transactionLimits,
+    limits: {
+      oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalHours,
+      ...userLimits,
+    },
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,12 +21,12 @@ try {
 
 export const yamlConfig = _.merge(defaultConfig, customConfig)
 
-const limitConstants = {
+export const limitConstants: LimitConstants = {
   oldEnoughForWithdrawalHours: yamlConfig.limits.oldEnoughForWithdrawal / MS_IN_HOUR,
   oldEnoughForWithdrawalMicroseconds: yamlConfig.limits.oldEnoughForWithdrawal,
 }
 
-export const selectUserLimits = ({ level }: { level: number }): IUserLimits => {
+export const selectUserLimits = ({ level }: UserLimitsArgs): IUserLimits => {
   const config = yamlConfig.limits
   return {
     onUsLimit: config.onUs.level[level],
@@ -34,16 +34,19 @@ export const selectUserLimits = ({ level }: { level: number }): IUserLimits => {
   }
 }
 
-export const getUserWalletConfig = (user): UserWalletConfig => {
-  const userLimits = selectUserLimits({ level: user.level })
+export const selectTransactionLimits = ({
+  level,
+}: UserLimitsArgs): ITransactionLimits => ({
+  oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalMicroseconds,
+  ...selectUserLimits({ level }),
+})
 
+export const getUserWalletConfig = (user): UserWalletConfig => {
+  const transactionLimits = selectTransactionLimits({ level: user.level })
   return {
     name: yamlConfig.name,
     dustThreshold: yamlConfig.onChainWallet.dustThreshold,
-    limits: {
-      oldEnoughForWithdrawalLimit: limitConstants.oldEnoughForWithdrawalHours,
-      ...userLimits,
-    },
+    limits: transactionLimits,
   }
 }
 

--- a/src/entrypoint/graphql-core-server.ts
+++ b/src/entrypoint/graphql-core-server.ts
@@ -16,7 +16,7 @@ import path from "path"
 
 import { baseLogger } from "../logger"
 import { addToMap, setAccountStatus, setLevel } from "../AdminOps"
-import { yamlConfig, levels, onboardingEarn } from "../config"
+import { yamlConfig, levels, onboardingEarn, selectTransactionLimits } from "../config"
 import { getActiveLnd, nodesStats, nodeStats } from "../lndUtils"
 import { getHourlyPrice, getMinBuildNumber } from "../localCache"
 import { sendNotification } from "../notifications/notification"
@@ -150,10 +150,11 @@ const resolvers = {
     },
     getLevels: () => levels,
     getLimits: (_, __, { user }) => {
+      const transactionLimits = selectTransactionLimits({ level: user.level })
       return {
-        oldEnoughForWithdrawal: yamlConfig.limits.oldEnoughForWithdrawal,
-        withdrawal: yamlConfig.limits.withdrawal.level[user.level],
-        onUs: yamlConfig.limits.onUs.level[user.level],
+        oldEnoughForWithdrawal: transactionLimits.oldEnoughForWithdrawalLimit,
+        withdrawal: transactionLimits.withdrawalLimit,
+        onUs: transactionLimits.onUsLimit,
       }
     },
     getWalletFees: () => ({

--- a/src/error.ts
+++ b/src/error.ts
@@ -131,7 +131,7 @@ export class RebalanceNeededError extends CustomError {
 
 export class DustAmountError extends CustomError {
   constructor(
-    message = `Use lightning to send amounts less than ${yamlConfig.onchainDustAmount}`,
+    message = `Use lightning to send amounts less than ${yamlConfig.onChainWallet.dustThreshold}`,
     { forwardToClient = true, logger, level = "warn" as const, ...metadata },
   ) {
     super(message, "ENTERED_DUST_AMOUNT", { forwardToClient, logger, level, metadata })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,12 +8,13 @@ type Primitive = string | boolean | number
 // configs & constructors
 // TODO: clean up this section when "constructor typing" work is
 //       being done
-interface ITransactionLimits {
-  config
-  level: number
-  onUsLimit: () => number
-  withdrawalLimit: () => number
-  oldEnoughForWithdrawalLimit: () => number
+interface IUserLimits {
+  onUsLimit: number
+  withdrawalLimit: number
+}
+
+interface ITransactionLimits extends IUserLimits {
+  oldEnoughForWithdrawalLimit: number
 }
 
 type UserWalletConfig = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,14 @@ type Primitive = string | boolean | number
 // configs & constructors
 // TODO: clean up this section when "constructor typing" work is
 //       being done
+
+type LimitConstants = {
+  oldEnoughForWithdrawalHours: number
+  oldEnoughForWithdrawalMicroseconds: number
+}
+
+type UserLimitsArgs = { level: number }
+
 interface IUserLimits {
   onUsLimit: number
   withdrawalLimit: number

--- a/test/integration/02-user-wallet/02-receive-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-receive-onchain.spec.ts
@@ -1,7 +1,7 @@
 import { once } from "events"
 import { filter } from "lodash"
 import { baseLogger } from "src/logger"
-import { TransactionLimits } from "src/config"
+import { selectUserLimits } from "src/config"
 import { getCurrentPrice } from "src/realtimePrice"
 import { btc2sat, sat2btc, sleep } from "src/utils"
 import { getFunderWallet } from "src/walletFactory"
@@ -30,9 +30,7 @@ let walletUser11
 let walletUser12
 let amountBTC
 
-const transactionLimits = new TransactionLimits({
-  level: "1",
-})
+const userLimits = selectUserLimits({ level: 1 })
 
 jest.mock("src/notifications/notification")
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -72,14 +70,14 @@ describe("UserWallet - On chain", () => {
 
   it("receives on-chain transaction with max limit for withdrawal level1", async () => {
     /// TODO? add sendAll tests in which the user has more than the limit?
-    const level1WithdrawalLimit = transactionLimits.withdrawalLimit() // sats
+    const level1WithdrawalLimit = userLimits.withdrawalLimit // sats
     amountBTC = sat2btc(level1WithdrawalLimit)
     walletUser11 = await getUserWallet(11)
     await sendToWallet({ walletDestination: walletUser11 })
   })
 
   it("receives on-chain transaction with max limit for onUs level1", async () => {
-    const level1OnUsLimit = transactionLimits.onUsLimit() // sats
+    const level1OnUsLimit = userLimits.onUsLimit // sats
     amountBTC = sat2btc(level1OnUsLimit)
     walletUser12 = await getUserWallet(12)
     await sendToWallet({ walletDestination: walletUser12 })

--- a/test/integration/02-user-wallet/02-send-lightning.spec.ts
+++ b/test/integration/02-user-wallet/02-send-lightning.spec.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto"
-import { TransactionLimits } from "src/config"
+import { selectUserLimits } from "src/config"
 import {
   InsufficientBalanceError,
   LightningPaymentError,
@@ -36,9 +36,7 @@ jest.mock("src/phone-provider", () => require("test/mocks/phone-provider"))
 let userWallet0, userWallet1, userWallet2
 let initBalance0, initBalance1
 const amountInvoice = 1000
-const transactionLimits = new TransactionLimits({
-  level: "1",
-})
+const userLimits = selectUserLimits({ level: 1 })
 
 beforeAll(async () => {
   userWallet0 = await getUserWallet(0)
@@ -208,7 +206,7 @@ describe("UserWallet - Lightning Pay", () => {
   it("fails to pay when withdrawalLimit exceeded", async () => {
     const { request } = await createInvoice({
       lnd: lndOutside1,
-      tokens: transactionLimits.withdrawalLimit() + 1,
+      tokens: userLimits.withdrawalLimit + 1,
     })
     await expect(userWallet1.pay({ invoice: request })).rejects.toThrow(
       TransactionRestrictedError,
@@ -217,7 +215,7 @@ describe("UserWallet - Lightning Pay", () => {
 
   it("fails to pay when amount exceeds onUs limit", async () => {
     const request = await userWallet0.addInvoice({
-      value: transactionLimits.onUsLimit() + 1,
+      value: userLimits.onUsLimit + 1,
     })
     await expect(userWallet1.pay({ invoice: request })).rejects.toThrow(
       TransactionRestrictedError,

--- a/test/integration/02-user-wallet/02-send-onchain.spec.ts
+++ b/test/integration/02-user-wallet/02-send-onchain.spec.ts
@@ -342,6 +342,9 @@ describe("UserWallet - onChainPay", () => {
       { $group: { _id: null, outgoingSats: { $sum: "$debit" } } },
     ])
     const { outgoingSats } = result || { outgoingSats: 0 }
+
+    // FIXME: 'withdrawalLimit' no longer exists as of
+    //        https://github.com/GaloyMoney/galoy/commit/2c3433ea42df59272c673bad473c95f524be8d9e#diff-94d4d5bb5c048793536625edb8adffb17e89b5f3821cec6d1c7c337578cda8e4L51
     const amount = yamlConfig.withdrawalLimit - outgoingSats
 
     await expect(userWallet0.onChainPay({ address, amount })).rejects.toThrow()
@@ -350,7 +353,10 @@ describe("UserWallet - onChainPay", () => {
   it("fails if the amount is less than on chain dust amount", async () => {
     const address = await bitcoindOutside.getNewAddress()
     expect(
-      userWallet0.onChainPay({ address, amount: yamlConfig.onchainDustAmount - 1 }),
+      userWallet0.onChainPay({
+        address,
+        amount: yamlConfig.onChainWallet.dustThreshold - 1,
+      }),
     ).rejects.toThrow()
   })
 })


### PR DESCRIPTION
## Description

_This is a temporary tracking PR meant to be closed (not merged) and recreated upstream when https://github.com/GaloyMoney/galoy/pull/382 gets merged._

This PR refactors the `TransactionLimits` class to instead be a function where the entire limits config is set up on function call instead of on individual method calls. It also splits off a `UserLimits` class to handle _level-specific_ limits. This split was done because there are places in the codebase where properties like `oldEnoughForWithdrawal` from the `TransactionLimits` object are called without needing a `level` value.

These changes are used to remove limits-related `yamlConfig` references from the `schema.ts` & `graphql-core-server.ts` files.